### PR TITLE
swap, suffix, CTOR and template

### DIFF
--- a/core/include/hash.hpp
+++ b/core/include/hash.hpp
@@ -3,8 +3,8 @@
 #include "type_traits.hpp"
 
 namespace cor {
-constexpr usize FNV_OFFSET_BASIS = 14695981039346656037u;
-constexpr usize FNV_prime        = 1099511628211u;
+constexpr usize FNV_OFFSET_BASIS = 14695981039346656037ull;
+constexpr usize FNV_prime        = 1099511628211ull;
 
 usize hash_FNV_1a(const unsigned char* first, usize count) {
     usize val = FNV_OFFSET_BASIS;

--- a/core/include/hash_table.hpp
+++ b/core/include/hash_table.hpp
@@ -112,7 +112,6 @@ public:
         }
     }
 
-    template <typename T>
     void remove(T key) {
         if (search(key)) {
             usize index = this->hashFunk(key);

--- a/core/include/memory.hpp
+++ b/core/include/memory.hpp
@@ -38,8 +38,8 @@ void deallocateArr(T* ptr) {
 }
 
 template <typename T>
-std::remove_extent_t<T>* allocate_r_extent(usize size) {
-    typedef std::remove_extent_t<T> Elem;
+cor::RemoveExtent_T<T>* allocate_r_extent(usize size) {
+    typedef cor::RemoveExtent_T<T> Elem;
     Elem* alocatedMem = DBG_NEW Elem[size]();
     return alocatedMem;
 }

--- a/core/include/range.hpp
+++ b/core/include/range.hpp
@@ -8,6 +8,10 @@ namespace cor {
 template <class T>
 class Slice {
 public:
+
+    constexpr Slice(const T* s, usize count) : first(s), ssize(count) {
+    }
+
     Slice(T* first = nullptr, T* last = nullptr)
         : first(first), ssize((last - first)) {
     }
@@ -68,11 +72,6 @@ class View {
 public:
     constexpr View(const T* s, usize count) : first(s), last(s + count) {
     }
-
-    /* TODO: se över detta
-constexpr View(const T* s) : first(s), last(s + cor::strlen(s)) {
-}
-    */
 
     View(T* first = nullptr, T* last = nullptr) : first(first), last(last) {
     }

--- a/core/include/utility.hpp
+++ b/core/include/utility.hpp
@@ -44,6 +44,14 @@ constexpr void iterSwap(Iter first, Iter second) {
     cor::moveSwap(*first, *second);
 }
 
+template <class T, size_t N>
+constexpr void swap(T (&a)[N], T (&b)[N]) noexcept {
+    auto tmp_a = a, tmp_b = b;
+    for (size_t i = 0; i < N; i++) {
+        iterSwap(tmp_a++, tmp_b++);
+    }
+}
+
 template <class T, class U = T>
 constexpr T exchange(T& obj, U&& new_value) {
     auto old_val = isMovable(obj);


### PR DESCRIPTION
swap overload for arr, range file removed constructor for View with range without size, added CTOR for Slice with range and size. memory now doesnt use std remove extent. integer width ull sufix for FNV variables in hash. removed unnessesary template<> from insert()